### PR TITLE
Pass value from entryPoint to toggleReadOnly

### DIFF
--- a/src/readonly.js
+++ b/src/readonly.js
@@ -116,7 +116,7 @@
         throw Error('readonly-js: element ' + target.nodeName + ' is not allowed');
       }
 
-      toggleReadOnly(target);
+      toggleReadOnly(target, value);
     });
   };
 


### PR DESCRIPTION
Currently the `value` parameter is being ignored and so calling with a value of `true` a second time will actually make the target(s) editable again.